### PR TITLE
syntax: Match lateinit modifier

### DIFF
--- a/syntax/Kotlin.YAML-tmLanguage
+++ b/syntax/Kotlin.YAML-tmLanguage
@@ -166,7 +166,7 @@ repository:
                 match: \b(data|inline|tailrec|operator|infix|typealias|reified)\b
                 name: storage.type.kotlin
             -
-                match: \b(external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|override|vararg|typealias|expect|actual|suspend|yield)\b
+                match: \b(external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|override|vararg|typealias|expect|actual|suspend|yield|lateinit)\b
                 name: storage.modifier.kotlin
             -
                 match: \b(try|catch|finally|throw)\b

--- a/syntax/Kotlin.tmLanguage
+++ b/syntax/Kotlin.tmLanguage
@@ -471,7 +471,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>\b(external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|override|vararg|typealias|expect|actual|suspend|yield)\b</string>
+            <string>\b(external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|override|vararg|typealias|expect|actual|suspend|yield|lateinit)\b</string>
             <key>name</key>
             <string>storage.modifier.kotlin</string>
           </dict>


### PR DESCRIPTION
Kotlin has had this for quite some time now but it's not being matched