### PR TITLE
Addresses double-quote in character issue from issue #26.

### DIFF
--- a/dist/Kotlin.JSON-tmLanguage
+++ b/dist/Kotlin.JSON-tmLanguage
@@ -731,7 +731,7 @@
               ]
             },
             {
-              "begin": "\"",
+              "begin": "(?!')\"(?!')",
               "beginCaptures": {
                 "0": {
                   "name": "punctuation.definition.string.begin.kotlin"

--- a/dist/Kotlin.YAML-tmLanguage
+++ b/dist/Kotlin.YAML-tmLanguage
@@ -297,7 +297,7 @@ repository:
             string:
                 patterns:
                     - {begin: '"""', beginCaptures: {'0': {name: punctuation.definition.string.begin.kotlin}}, end: '"""', endCaptures: {'0': {name: punctuation.definition.string.end.kotlin}}, name: string.quoted.triple.kotlin, patterns: [{include: '#string-content'}]}
-                    - {begin: '"', beginCaptures: {'0': {name: punctuation.definition.string.begin.kotlin}}, end: '"', endCaptures: {'0': {name: punctuation.definition.string.end.kotlin}}, name: string.quoted.double.kotlin, patterns: [{include: '#string-content'}]}
+                    - {begin: '(?!'')"(?!'')', beginCaptures: {'0': {name: punctuation.definition.string.begin.kotlin}}, end: '"', endCaptures: {'0': {name: punctuation.definition.string.end.kotlin}}, name: string.quoted.double.kotlin, patterns: [{include: '#string-content'}]}
                 repository:
                     string-content: {patterns: [{match: '\\[0\\tnr"'']', name: constant.character.escape.kotlin}, {match: '\\(x[\da-fA-F]{2}|u[\da-fA-F]{4}|.)', name: constant.character.escape.unicode.kotlin}, {begin: '\$(\{)', beginCaptures: {'1': {name: punctuation.section.block.begin.kotlin}}, end: '\}', endCaptures: {'0': {name: punctuation.section.block.end.kotlin}}, name: entity.string.template.element.kotlin}, {match: '\$[a-zA-Z_]\w*', name: entity.string.template.element.kotlin}]}
             'null':

--- a/dist/Kotlin.tmLanguage
+++ b/dist/Kotlin.tmLanguage
@@ -1104,7 +1104,7 @@
               </dict>
               <dict>
                 <key>begin</key>
-                <string>"</string>
+                <string>(?!')"(?!')</string>
                 <key>beginCaptures</key>
                 <dict>
                   <key>0</key>

--- a/src/literals.YAML-tmLanguage
+++ b/src/literals.YAML-tmLanguage
@@ -45,7 +45,7 @@ repository:
                             -
                                 include: '#string-content'
                     -
-                        begin: '"'
+                        begin: '(?!'')"(?!'')'
                         beginCaptures:
                             '0':
                                 name: punctuation.definition.string.begin.kotlin

--- a/test/literals.test.kt
+++ b/test/literals.test.kt
@@ -168,3 +168,9 @@
 //                    ^ source.kotlin string.quoted.double.kotlin punctuation.definition.string.begin.kotlin
 //                     ^^^^^^ source.kotlin string.quoted.double.kotlin constant.character.escape.unicode.kotlin
 //                           ^ source.kotlin string.quoted.double.kotlin punctuation.definition.string.end.kotlin
+
+  foo('"')
+//^^^ source.kotlin
+//   ^ source.kotlin meta.group.kotlin punctuation.section.group.begin.kotlin
+//    ^^^ source.kotlin meta.group.kotlin
+//       ^ source.kotlin meta.group.kotlin punctuation.section.group.end.kotlin

--- a/test/regression/26.test.kt
+++ b/test/regression/26.test.kt
@@ -1,6 +1,8 @@
 // SYNTAX TEST "source.kotlin" "Double quotes in character value."
-  foo('"')
-//^^^ source.kotlin
-//   ^ source.kotlin meta.group.kotlin punctuation.section.group.begin.kotlin
-//    ^^^ source.kotlin meta.group.kotlin
-//       ^ source.kotlin meta.group.kotlin punctuation.section.group.end.kotlin
+
+   foo('"')
+//      ^ -string.quoted.double.kotlin
+
+   val same = '"' == '"'
+//             ^ -string.quoted.double.kotlin
+//                    ^ -string.quoted.double.kotlin

--- a/test/regression/26.test.kt
+++ b/test/regression/26.test.kt
@@ -1,0 +1,6 @@
+// SYNTAX TEST "source.kotlin" "Double quotes in character value."
+  foo('"')
+//^^^ source.kotlin
+//   ^ source.kotlin meta.group.kotlin punctuation.section.group.begin.kotlin
+//    ^^^ source.kotlin meta.group.kotlin
+//       ^ source.kotlin meta.group.kotlin punctuation.section.group.end.kotlin


### PR DESCRIPTION
Uses a negative lookahead regex to ensure that no single quote is
allowed on either side of the double-quote.

Verified using Lightshow on the following source:
https://github.com/shaeberling/euler/blob/master/kotlin/src/com/s13g/aoc/aoc2020/Day19.kt

Also added a regression test case that will fail without this change.