### PR TITLE
Fix issue with quotes inside tripple quoted string (Issue #26)

### DIFF
--- a/dist/Kotlin.JSON-tmLanguage
+++ b/dist/Kotlin.JSON-tmLanguage
@@ -717,7 +717,7 @@
                   "name": "punctuation.definition.string.begin.kotlin"
                 }
               },
-              "end": "\"\"\"",
+              "end": "\"\"\"(?!\")",
               "endCaptures": {
                 "0": {
                   "name": "punctuation.definition.string.end.kotlin"

--- a/dist/Kotlin.YAML-tmLanguage
+++ b/dist/Kotlin.YAML-tmLanguage
@@ -296,7 +296,7 @@ repository:
                     - {match: '\b([0-9][0-9_]*([fFLuU]|[uU]L)?)\b', name: constant.numeric.integer.kotlin}
             string:
                 patterns:
-                    - {begin: '"""', beginCaptures: {'0': {name: punctuation.definition.string.begin.kotlin}}, end: '"""', endCaptures: {'0': {name: punctuation.definition.string.end.kotlin}}, name: string.quoted.triple.kotlin, patterns: [{include: '#string-content'}]}
+                    - {begin: '"""', beginCaptures: {'0': {name: punctuation.definition.string.begin.kotlin}}, end: '"""(?!")', endCaptures: {'0': {name: punctuation.definition.string.end.kotlin}}, name: string.quoted.triple.kotlin, patterns: [{include: '#string-content'}]}
                     - {begin: '(?!'')"(?!'')', beginCaptures: {'0': {name: punctuation.definition.string.begin.kotlin}}, end: '"', endCaptures: {'0': {name: punctuation.definition.string.end.kotlin}}, name: string.quoted.double.kotlin, patterns: [{include: '#string-content'}]}
                 repository:
                     string-content: {patterns: [{match: '\\[0\\tnr"'']', name: constant.character.escape.kotlin}, {match: '\\(x[\da-fA-F]{2}|u[\da-fA-F]{4}|.)', name: constant.character.escape.unicode.kotlin}, {begin: '\$(\{)', beginCaptures: {'1': {name: punctuation.section.block.begin.kotlin}}, end: '\}', endCaptures: {'0': {name: punctuation.section.block.end.kotlin}}, name: entity.string.template.element.kotlin}, {match: '\$[a-zA-Z_]\w*', name: entity.string.template.element.kotlin}]}

--- a/dist/Kotlin.tmLanguage
+++ b/dist/Kotlin.tmLanguage
@@ -1083,7 +1083,7 @@
                   </dict>
                 </dict>
                 <key>end</key>
-                <string>"""</string>
+                <string>"""(?!")</string>
                 <key>endCaptures</key>
                 <dict>
                   <key>0</key>

--- a/src/literals.YAML-tmLanguage
+++ b/src/literals.YAML-tmLanguage
@@ -36,7 +36,7 @@ repository:
                         beginCaptures:
                             '0':
                                 name: punctuation.definition.string.begin.kotlin
-                        end: '"""'
+                        end: '"""(?!")'
                         endCaptures:
                             '0':
                                 name: punctuation.definition.string.end.kotlin

--- a/test/literals.test.kt
+++ b/test/literals.test.kt
@@ -174,3 +174,11 @@
 //   ^ source.kotlin meta.group.kotlin punctuation.section.group.begin.kotlin
 //    ^^^ source.kotlin meta.group.kotlin
 //       ^ source.kotlin meta.group.kotlin punctuation.section.group.end.kotlin
+
+  foo(""""."""")
+//^^^ source.kotlin
+//   ^ source.kotlin meta.group.kotlin punctuation.section.group.begin.kotlin
+//    ^^^ source.kotlin meta.group.kotlin string.quoted.triple.kotlin punctuation.definition.string.begin.kotlin
+//        ^^^ source.kotlin meta.group.kotlin string.quoted.triple.kotlin
+//          ^^^ source.kotlin meta.group.kotlin string.quoted.triple.kotlin punctuation.definition.string.end.kotlin
+//             ^ source.kotlin meta.group.kotlin punctuation.section.group.end.kotlin

--- a/test/regression/26.test.kt
+++ b/test/regression/26.test.kt
@@ -1,4 +1,4 @@
-// SYNTAX TEST "source.kotlin" "Double quotes in character value."
+// SYNTAX TEST "source.kotlin" "Double quotes in character value and quadrupel double quotes"
 
    foo('"')
 //      ^ -string.quoted.double.kotlin
@@ -6,3 +6,9 @@
    val same = '"' == '"'
 //             ^ -string.quoted.double.kotlin
 //                    ^ -string.quoted.double.kotlin
+
+   foo(""""."""")
+//^^^^ source.kotlin
+//          ^ -punctuation.definition.string.end.kotlin
+//             ^ -punctuation.definition.string.begin.kotlin
+//              ^^ -string.quoted.double.kotlin


### PR DESCRIPTION
This ensures that a tripple quoted string is not closed until the
last quote. Before this patch it would try to start closing the
triple quote starting the first quote it encounters.