### PR TITLE
Fixes recognition of single-lettered class and enum entry (Fixes #38)

### DIFF
--- a/dist/Kotlin.JSON-tmLanguage
+++ b/dist/Kotlin.JSON-tmLanguage
@@ -377,7 +377,7 @@
     "class-ident": {
       "patterns": [
         {
-          "match": "\\b[A-Z]\\w+\\b",
+          "match": "\\b[A-Z_]\\w*\\b",
           "name": "entity.name.type.class.kotlin",
           "comment": "Classes generally start with an Uppercase Char"
         }

--- a/dist/Kotlin.YAML-tmLanguage
+++ b/dist/Kotlin.YAML-tmLanguage
@@ -96,7 +96,7 @@ repository:
     class-ident:
         patterns:
             -
-                match: '\b[A-Z]\w+\b'
+                match: '\b[A-Z_]\w*\b'
                 name: entity.name.type.class.kotlin
                 comment: 'Classes generally start with an Uppercase Char'
     imports:

--- a/dist/Kotlin.tmLanguage
+++ b/dist/Kotlin.tmLanguage
@@ -576,7 +576,7 @@
         <array>
           <dict>
             <key>match</key>
-            <string>\b[A-Z]\w+\b</string>
+            <string>\b[A-Z_]\w*\b</string>
             <key>name</key>
             <string>entity.name.type.class.kotlin</string>
             <key>comment</key>

--- a/snapshots/corpus.kt
+++ b/snapshots/corpus.kt
@@ -55,7 +55,7 @@ suspend fun <T, U> SequenceBuilder<Int>.yieldIfOdd(x: Int) {
     if (x % 2 != 0) yield(x)
 }
 
-val function = fun(@Inject x: Int, y: Int, lamda: (A, B) -> Unit): Int {
+val function = fun(@Inject x: Int, y: Int, lambda: (A, B) -> Unit): Int {
     test.test()
     return x + y;
 }

--- a/snapshots/corpus.kt.snap
+++ b/snapshots/corpus.kt.snap
@@ -338,7 +338,7 @@
 >}
 #^ source.kotlin meta.function.kotlin meta.block.kotlin punctuation.section.group.end.kotlin
 >
->val function = fun(@Inject x: Int, y: Int, lamda: (A, B) -> Unit): Int {
+>val function = fun(@Inject x: Int, y: Int, lambda: (A, B) -> Unit): Int {
 #^^^ source.kotlin storage.type.kotlin
 #   ^^^^^^^^^^ source.kotlin
 #             ^ source.kotlin keyword.operator.assignment.kotlin
@@ -360,21 +360,23 @@
 #                                         ^ source.kotlin meta.function.kotlin meta.parameters.kotlin punctuation.seperator.kotlin
 #                                          ^ source.kotlin meta.function.kotlin meta.parameters.kotlin
 #                                           ^^^^^ source.kotlin meta.function.kotlin meta.parameters.kotlin variable.parameter.function.kotlin
-#                                                ^ source.kotlin meta.function.kotlin meta.parameters.kotlin keyword.operator.declaration.kotlin
-#                                                 ^ source.kotlin meta.function.kotlin meta.parameters.kotlin
-#                                                  ^ source.kotlin meta.function.kotlin meta.parameters.kotlin punctuation.section.group.begin.kotlin
-#                                                   ^^^^ source.kotlin meta.function.kotlin meta.parameters.kotlin
-#                                                       ^ source.kotlin meta.function.kotlin meta.parameters.kotlin punctuation.section.group.end.kotlin
-#                                                        ^ source.kotlin meta.function.kotlin meta.parameters.kotlin
-#                                                         ^^ source.kotlin meta.function.kotlin meta.parameters.kotlin keyword.operator.type.function.kotlin
-#                                                           ^ source.kotlin meta.function.kotlin meta.parameters.kotlin
-#                                                            ^^^^ source.kotlin meta.function.kotlin meta.parameters.kotlin support.class.kotlin
-#                                                                ^ source.kotlin meta.function.kotlin meta.parameters.kotlin punctuation.section.group.end.kotlin punctuation.definition.parameters.end.kotlin
-#                                                                 ^ source.kotlin meta.function.kotlin meta.return.type.kotlin
+#                                                 ^ source.kotlin meta.function.kotlin meta.parameters.kotlin keyword.operator.declaration.kotlin
+#                                                  ^ source.kotlin meta.function.kotlin meta.parameters.kotlin
+#                                                   ^ source.kotlin meta.function.kotlin meta.parameters.kotlin punctuation.section.group.begin.kotlin
+#                                                    ^ source.kotlin meta.function.kotlin meta.parameters.kotlin entity.name.type.class.kotlin
+#                                                     ^^ source.kotlin meta.function.kotlin meta.parameters.kotlin
+#                                                       ^ source.kotlin meta.function.kotlin meta.parameters.kotlin entity.name.type.class.kotlin
+#                                                        ^ source.kotlin meta.function.kotlin meta.parameters.kotlin punctuation.section.group.end.kotlin
+#                                                         ^ source.kotlin meta.function.kotlin meta.parameters.kotlin
+#                                                          ^^ source.kotlin meta.function.kotlin meta.parameters.kotlin keyword.operator.type.function.kotlin
+#                                                            ^ source.kotlin meta.function.kotlin meta.parameters.kotlin
+#                                                             ^^^^ source.kotlin meta.function.kotlin meta.parameters.kotlin support.class.kotlin
+#                                                                 ^ source.kotlin meta.function.kotlin meta.parameters.kotlin punctuation.section.group.end.kotlin punctuation.definition.parameters.end.kotlin
 #                                                                  ^ source.kotlin meta.function.kotlin meta.return.type.kotlin
-#                                                                   ^^^ source.kotlin meta.function.kotlin meta.return.type.kotlin support.class.kotlin
-#                                                                      ^ source.kotlin meta.function.kotlin meta.return.type.kotlin
-#                                                                       ^ source.kotlin meta.function.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
+#                                                                   ^ source.kotlin meta.function.kotlin meta.return.type.kotlin
+#                                                                    ^^^ source.kotlin meta.function.kotlin meta.return.type.kotlin support.class.kotlin
+#                                                                       ^ source.kotlin meta.function.kotlin meta.return.type.kotlin
+#                                                                        ^ source.kotlin meta.function.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
 >    test.test()
 #^^^^^^^^ source.kotlin meta.function.kotlin meta.block.kotlin
 #        ^ source.kotlin meta.function.kotlin meta.block.kotlin punctuation.accessor.dot.kotlin
@@ -845,7 +847,11 @@
 #               ^^^^^ source.kotlin meta.class.kotlin storage.modifier.kotlin
 #                    ^ source.kotlin meta.class.kotlin
 #                     ^^^^^^^^^^^^^ source.kotlin meta.class.kotlin entity.name.class.kotlin
-#                                  ^^^^^^^ source.kotlin meta.class.kotlin
+#                                  ^ source.kotlin meta.class.kotlin
+#                                   ^ source.kotlin meta.class.kotlin entity.name.type.class.kotlin
+#                                    ^^ source.kotlin meta.class.kotlin
+#                                      ^ source.kotlin meta.class.kotlin entity.name.type.class.kotlin
+#                                       ^^ source.kotlin meta.class.kotlin
 #                                         ^^^^^^^ source.kotlin meta.class.kotlin meta.annotation.kotlin
 #                                                ^^^^^^^^^^^^ source.kotlin meta.class.kotlin
 #                                                            ^ source.kotlin meta.class.kotlin meta.parameters.kotlin punctuation.section.group.begin.kotlin punctuation.definition.parameters.begin.kotlin

--- a/src/ident.YAML-tmLanguage
+++ b/src/ident.YAML-tmLanguage
@@ -2,6 +2,6 @@ repository:
     class-ident:
         patterns:
             -
-                match: '\b[A-Z]\w+\b'
+                match: '\b[A-Z_]\w*\b'
                 name: entity.name.type.class.kotlin
                 comment: 'Classes generally start with an Uppercase Char'

--- a/test/ClassDeclaration.test.kt
+++ b/test/ClassDeclaration.test.kt
@@ -36,3 +36,8 @@ actual class Foo(bar: String) {
 }
 // <--- ^ punctuation.section.group.begin.kotlin
 
+enum class A {
+//         ^ source.kotlin meta.class.kotlin entity.name.class.kotlin
+    B
+//  ^ source.kotlin meta.class.kotlin meta.block.kotlin entity.name.type.class.kotlin
+}


### PR DESCRIPTION
Fixes the single-lettered highlighting of class and enum-entry by `OR`(ing) with single-lettered capital word which is not before  `>`.

Should be merged after PR #37 because this contains another commit over it 😅.