### PR TITLE
Add `inner` keyword

### DIFF
--- a/dist/Kotlin.JSON-tmLanguage
+++ b/dist/Kotlin.JSON-tmLanguage
@@ -614,7 +614,7 @@
           "name": "storage.modifier.kotlin"
         },
         {
-          "match": "\\b(?<![+-/%*=(,]\\s)(inline|external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|expect|actual|const|lateinit)(?=\\s(?!(?:\\s*)(?:[+-/%*=:).,]|$)))\\b",
+          "match": "\\b(?<![+-/%*=(,]\\s)(inline|inner|external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|expect|actual|const|lateinit)(?=\\s(?!(?:\\s*)(?:[+-/%*=:).,]|$)))\\b",
           "name": "storage.modifier.kotlin",
           "comment": "Soft modifiers"
         },

--- a/dist/Kotlin.YAML-tmLanguage
+++ b/dist/Kotlin.YAML-tmLanguage
@@ -218,7 +218,7 @@ repository:
                 match: \b(out|in|yield|typealias|override)\b
                 name: storage.modifier.kotlin
             -
-                match: '\b(?<![+-/%*=(,]\s)(inline|external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|expect|actual|const|lateinit)(?=\s(?!(?:\s*)(?:[+-/%*=:).,]|$)))\b'
+                match: '\b(?<![+-/%*=(,]\s)(inline|inner|external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|expect|actual|const|lateinit)(?=\s(?!(?:\s*)(?:[+-/%*=:).,]|$)))\b'
                 name: storage.modifier.kotlin
                 comment: 'Soft modifiers'
             -

--- a/dist/Kotlin.tmLanguage
+++ b/dist/Kotlin.tmLanguage
@@ -926,7 +926,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>\b(?&lt;![+-/%*=(,]\s)(inline|external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|expect|actual|const|lateinit)(?=\s(?!(?:\s*)(?:[+-/%*=:).,]|$)))\b</string>
+            <string>\b(?&lt;![+-/%*=(,]\s)(inline|inner|external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|expect|actual|const|lateinit)(?=\s(?!(?:\s*)(?:[+-/%*=:).,]|$)))\b</string>
             <key>name</key>
             <string>storage.modifier.kotlin</string>
             <key>comment</key>

--- a/snapshots/corpus.kt
+++ b/snapshots/corpus.kt
@@ -160,3 +160,7 @@ object DefaultListener : MouseAdapter() {
 class Feature : Node("Title", "Content", "Description") {
 
 }
+
+class Outer {
+    inner class Inner {}
+}

--- a/snapshots/corpus.kt.snap
+++ b/snapshots/corpus.kt.snap
@@ -1149,3 +1149,22 @@
 >
 >}
 #^ source.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.end.kotlin
+>
+>class Outer {
+#^^^^^ source.kotlin meta.class.kotlin storage.modifier.kotlin
+#     ^ source.kotlin meta.class.kotlin
+#      ^^^^^ source.kotlin meta.class.kotlin entity.name.class.kotlin
+#           ^ source.kotlin meta.class.kotlin
+#            ^ source.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
+>    inner class Inner {}
+#^^^^ source.kotlin meta.class.kotlin meta.block.kotlin
+#    ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin storage.modifier.kotlin
+#         ^ source.kotlin meta.class.kotlin meta.block.kotlin
+#          ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin storage.modifier.kotlin
+#               ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin
+#                ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin entity.name.class.kotlin
+#                     ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin
+#                      ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
+#                       ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.end.kotlin
+>}
+#^ source.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.end.kotlin

--- a/src/keywords.YAML-tmLanguage
+++ b/src/keywords.YAML-tmLanguage
@@ -20,7 +20,7 @@ repository:
                 match: \b(out|in|yield|typealias|override)\b
                 name: storage.modifier.kotlin
             -
-                match: \b(?<![+-/%*=(,]\s)(inline|external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|expect|actual|const|lateinit)(?=\s(?!(?:\s*)(?:[+-/%*=:).,]|$)))\b
+                match: \b(?<![+-/%*=(,]\s)(inline|inner|external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|expect|actual|const|lateinit)(?=\s(?!(?:\s*)(?:[+-/%*=:).,]|$)))\b
                 name: storage.modifier.kotlin
                 comment: 'Soft modifiers'
             -

--- a/test/regression/63.test.kt
+++ b/test/regression/63.test.kt
@@ -1,0 +1,20 @@
+// SYNTAX TEST "source.kotlin" "Keywords"
+
+class Outer {
+//^^^^^ source.kotlin meta.class.kotlin storage.modifier.kotlin
+//     ^ source.kotlin meta.class.kotlin
+//      ^^^^^ source.kotlin meta.class.kotlin entity.name.class.kotlin
+//           ^ source.kotlin meta.class.kotlin
+//            ^ source.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
+    inner class Inner {}
+//  ^^^^ source.kotlin meta.class.kotlin meta.block.kotlin
+//      ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin storage.modifier.kotlin
+//           ^ source.kotlin meta.class.kotlin meta.block.kotlin
+//            ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin storage.modifier.kotlin
+//                 ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin
+//                  ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin entity.name.class.kotlin
+//                       ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin
+//                        ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
+//                         ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.end.kotlin
+}
+//^ source.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.end.kotlin

--- a/test/regression/63.test.kt
+++ b/test/regression/63.test.kt
@@ -1,20 +1,20 @@
-// SYNTAX TEST "source.kotlin" "Keywords"
+// SYNTAX TEST "source.kotlin" "Recognize inner modifier"
 
-class Outer {
-//^^^^^ source.kotlin meta.class.kotlin storage.modifier.kotlin
-//     ^ source.kotlin meta.class.kotlin
-//      ^^^^^ source.kotlin meta.class.kotlin entity.name.class.kotlin
-//           ^ source.kotlin meta.class.kotlin
-//            ^ source.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
-    inner class Inner {}
-//  ^^^^ source.kotlin meta.class.kotlin meta.block.kotlin
-//      ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin storage.modifier.kotlin
-//           ^ source.kotlin meta.class.kotlin meta.block.kotlin
-//            ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin storage.modifier.kotlin
-//                 ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin
-//                  ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin entity.name.class.kotlin
-//                       ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin
-//                        ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
-//                         ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.end.kotlin
-}
-//^ source.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.end.kotlin
+>class Outer {
+#^^^^^ source.kotlin meta.class.kotlin storage.modifier.kotlin
+#     ^ source.kotlin meta.class.kotlin
+#      ^^^^^ source.kotlin meta.class.kotlin entity.name.class.kotlin
+#           ^ source.kotlin meta.class.kotlin
+#            ^ source.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
+>    inner class Inner {}
+#^^^^ source.kotlin meta.class.kotlin meta.block.kotlin
+#    ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin storage.modifier.kotlin
+#         ^ source.kotlin meta.class.kotlin meta.block.kotlin
+#          ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin storage.modifier.kotlin
+#               ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin
+#                ^^^^^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin entity.name.class.kotlin
+#                     ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin
+#                      ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.begin.kotlin
+#                       ^ source.kotlin meta.class.kotlin meta.block.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.end.kotlin
+>}
+#^ source.kotlin meta.class.kotlin meta.block.kotlin punctuation.section.group.end.kotlin


### PR DESCRIPTION
Support `inner` keyword.

A nested class marked as inner can access the members of its outer class. Inner classes carry a reference to an object of an outer class:
```kotlin
class Outer {
    private val bar: Int = 1
    inner class Inner {
        fun foo() = bar
    }
}

val demo = Outer().Inner().foo() // == 1
```